### PR TITLE
add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,91 @@
+# Academic Use Licence
+
+**These licence terms apply to all licences granted by THE CHANCELLOR, MASTERS AND SCHOLARS OF THE UNIVERSITY OF OXFORD whose administrative offices are at University Offices, Wellington Square, Oxford OX1 2JD, United Kingdom (the “University”) for use of “stepcount” (“the Software”) through this website (https://github.com/OxWearables) (the ”Website”).**
+
+**By downloading the Software through the Website, you (the “Licensee”) are confirming that you agree that your use of the Software is subject to these licence terms**
+
+**PLEASE READ THESE LICENCE TERMS CAREFULLY BEFORE DOWNLOADING THE SOFTWARE. IF YOU DO NOT AGREE TO THESE LICENCE TERMS YOU SHOULD NOT DOWNLOAD THE SOFTWARE.**
+
+**THE SOFTWARE IS INTENDED FOR USE BY ACADEMICS CARRYING OUT RESEARCH AND NOT FOR USE BY CONSUMERS OR COMMERCIAL BUSINESSES.**
+
+**1.	Academic Use Licence**
+
+1.1	The Licensee is granted a limited non-exclusive and non-transferable royalty free licence to download and use the Software provided that the Licensee will:
+
+- (a)	limit their use of the Software to their own internal academic non-commercial research which is undertaken for the purposes of education or other scholarly use;
+- (b)	not use the Software for or on behalf of any third party or to provide a service or integrate all or part of the Software into a product for sale or license to third parties;
+- (c)	use the Software in accordance with the prevailing instructions and guidance for use given on the Website and comply with procedures on the Website for user identification, authentication and access;
+- (d)	comply with all applicable laws and regulations with respect to their use of the Software; and
+- (e)	ensure that the Copyright Notice “Copyright © 2023, University of Oxford” appears prominently wherever the Software is reproduced and is referenced or cited with the Copyright Notice when the Software is described in any research publication or on any documents or other material created using the Software.
+
+1.2	The Licensee may only reproduce, modify, transmit or transfer the Software where:
+
+- (a)	such reproduction, modification, transmission or transfer is for academic, research or other scholarly use;
+- (b)	the conditions of this Licence are imposed upon the receiver of the Software or any modified Software;
+- (c)	all original and modified Source Code is included in any transmitted software program; and
+- (d)	the Licensee grants the University an irrevocable, indefinite, royalty free, non-exclusive unlimited licence to use and sub-licence any modified Source Code as part of the Software.
+
+1.3	The University reserves the right at any time and without liability or prior notice to the Licensee to revise, modify and replace the functionality and performance of the access to and operation of the Software.
+
+1.4	The Licensee acknowledges and agrees that the University owns all intellectual property rights in the Software.  The Licensee shall not have any right, title or interest in the Software.
+
+1.5	This Licence will terminate immediately and the Licensee will no longer have any right to use the Software or exercise any of the rights granted to the Licensee upon any breach of the conditions in Section 1 of this Licence.
+
+
+**2.	Indemnity and Liability**
+
+2.1	The Licensee shall defend, indemnify and hold harmless the University against any claims, actions, proceedings, losses, damages, expenses and costs (including without limitation court costs and reasonable legal fees) arising out of or in connection with the Licensee's possession or use of the Software, or any breach of these terms by the Licensee.
+
+2.2	The Software is provided on an ‘as is’ basis and the Licensee uses the Software at their own risk. No representations, conditions, warranties or other terms of any kind are given in respect of the the Software and all statutory warranties and conditions are excluded to the fullest extent permitted by law. Without affecting the generality of the previous sentences, the University gives no implied or express warranty and makes no representation that the Software or any part of the Software: 
+
+- (a) will enable specific results to be obtained; or 
+- (b) meets a particular specification or is comprehensive within its field or that it is error free or will operate without interruption; or 
+- (c) is suitable for any particular, or the Licensee's specific purposes.
+
+2.3	Except in relation to fraud, death or personal injury, the University's liability to the Licensee for any use of the Software, in negligence or arising in any other way out of the subject matter of these licence terms, will not extend to any incidental or consequential damages or losses, or any loss of profits, loss of revenue, loss of data, loss of contracts or opportunity, whether direct or indirect.
+
+2.4	The Licensee hereby irrevocably undertakes to the University not to make any claim against any employee, student, researcher or other individual engaged by the University, being a claim which seeks to enforce against any of them any liability whatsoever in connection with these licence terms or their subject-matter.
+
+**3.	General**
+
+**3.1	Severability** - If any provision (or part of a provision) of these licence terms is found by any court or administrative body of competent jurisdiction to be invalid, unenforceable or illegal, the other provisions shall remain in force.
+
+**3.2	Entire Agreement** - These licence terms constitute the whole agreement between the parties and supersede any previous arrangement, understanding or agreement between them relating to the Software.
+
+**3.3	Law and Jurisdiction** - These licence terms and any disputes or claims arising out of or in connection with them shall be governed by, and construed in accordance with, the law of England. The Licensee irrevocably submits to the exclusive jurisdiction of the English courts for any dispute or claim that arises out of or in connection with these licence terms.
+
+If you are interested in using the Software commercially, please contact Oxford University Innovation Limited to negotiate a licence. Contact details are enquiries@innovation.ox.ac.uk
+
+----------------------------------
+ 
+Java code to read Axivity AX3 raw sensor data, whilst not being the property of Oxford, are released under the terms of the main Oxford Wearables Group licence above. The particular files are: AxivityReader.java, BandpassFiler.java, LowpassFilter.java. These three files were developed under the below license:
+ 
+Copyright (c) 2014
+Aiden Doherty, University of Oxford
+Nils Hammerla, Newcastle University
+Dan Jackson, Newcastle University
+Shing Chan, University of Oxford
+Rosemary Walmsley, University of Oxford
+Hang Yuan, University of Oxford
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+ 
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Adding the standard BBAA license as LICENSE.md into the stepcount package. The software name and copyright year have changed, though other details may need amended