### PR TITLE
Correct acf_zeros calculation

### DIFF
--- a/src/stepcount/features.py
+++ b/src/stepcount/features.py
@@ -92,8 +92,7 @@ def autocorr_features(v, sample_rate):
     else:
         acf_1st_min = acf_1st_min_loc = 0.0
 
-    acf_zeros = np.where(np.diff(np.signbit(u)))
-    acf_zeros = len(acf_zeros)
+    acf_zeros = np.sum(np.diff(np.signbit(u)))
 
     feats = {
         'acf_1st_max': acf_1st_max,


### PR DESCRIPTION
This seeks to address a bug identified in #6 

Here we ensure that acf_zeros is correctly calculated, rather than always returning 1.