### PR TITLE
Feature: Step Timings

### DIFF
--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -69,10 +69,12 @@ def main():
 
     if verbose:
         print("Running step counter...")
-    Y = model.predict_from_frame(data)
+    Y, W, T_steps = model.predict_from_frame(data)
 
-    # Save raw output timeseries
-    Y.rename('Steps').to_csv(f"{outdir}/{basename}-Steps.csv")
+    # Save step counts
+    Y.to_csv(f"{outdir}/{basename}-Steps.csv")
+    # Save timestamps of each step
+    T_steps.to_csv(f"{outdir}/{basename}-StepTimes.csv", index=False)
 
     # Summary
     summary = summarize(Y, model.steptol)


### PR DESCRIPTION
This introduces a new feature, in which a csv is outputted for the time of each detected step.

Note that to do so, this has also:

* Reformatted code according to Black code formatter
* Refactored code to count peaks by now using the function to find the peak timings and counting for each batch

I have successfully tested this on a sample file by running: `stepcount sample.csv --step-timings`
I have not updated any package versions until confirmation from @chanshing 