### PR TITLE
more flexible NA handling when adjusted estimation

### DIFF
--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -466,9 +466,9 @@ def summarize_cadence(Y, steptol=3, exclude_wear_below=None, exclude_first_last=
 
     # cadence https://jamanetwork.com/journals/jama/fullarticle/2763292
 
-    daily_cadence_peak1 = minutely.resample('D').agg(_cadence_max, steptol=steptol_in_minutes, n=1).rename('CadencePeak1(steps/min)')
-    daily_cadence_peak30 = minutely.resample('D').agg(_cadence_max, steptol=steptol_in_minutes, n=30).rename('CadencePeak30(steps/min)')
-    daily_cadence_p95 = minutely.resample('D').agg(_cadence_p95, steptol=steptol_in_minutes).rename('Cadence95th(steps/min)')
+    daily_cadence_peak1 = minutely.resample('D').agg(_cadence_max, steptol=steptol_in_minutes, walktol=10, n=1).rename('CadencePeak1(steps/min)')
+    daily_cadence_peak30 = minutely.resample('D').agg(_cadence_max, steptol=steptol_in_minutes, walktol=30, n=30).rename('CadencePeak30(steps/min)')
+    daily_cadence_p95 = minutely.resample('D').agg(_cadence_p95, walktol=10, steptol=steptol_in_minutes).rename('Cadence95th(steps/min)')
 
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', message='Mean of empty slice')

--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -583,7 +583,7 @@ def impute_missing(data: pd.DataFrame, extrapolate=True, skip_full_missing_days=
 
     if skip_full_missing_days:
         # find ok days
-        ok = data.notna().groupby(data.index.date).all()
+        ok = data.notna().groupby(data.index.date).any()
         ok = np.isin(data.index.date, ok[ok].index)
         # impute only on ok days
         data.loc[ok] = impute(data.loc[ok])


### PR DESCRIPTION
Set a min wear criteria in aggregation: Instead of setting to NA when any NA, allow for some missingness. Defaults:
- Up to 30s/min missing when calculating minutely
- Up to 10min/h missing when calculating hourly
- Up to 3h/d missing when calculating daily

For example, if day has 4h missing data, that day's step and walk will be NA.
Crude (unadjusted) values will still always report the agg for that day.

For cadence (peak1, peak30, 95th):
- At least 10min in the day to calculate peak1 and 95th, otherwise set to NA for that day
- At least 30min in the day to calculate 95th, otherwise set to NA for that day