### PR TITLE
feat: detect activity bouts and calculate bout metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setuptools.setup(
         "hmmlearn==0.3.*",
         "torch==1.13.*",
         "torchvision==0.14.*",
-        "transforms3d==0.4.*"
+        "transforms3d==0.4.*",
+        "numba==0.58.*"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Detect bouts of activity and calculate bout metrics.

Result is a dataframe (each row is a bout) with the following columns:

- StartTime: Bout start time.
- EndTime: Bout end time.
- Duration(mins): Bout duration (in minutes).
- TimeSinceLast(mins): Time since end of last bout (in minutes).
- Steps: Number of steps in the bout.
- Cadence(steps/min): Bout cadence (steps per minute).
- CadenceSD(steps/min): Bout cadence standard deviation (steps per minute).
- Cadence25th(steps/min): 25th percentile cadence (steps per minute) in the bout.
- Cadence50th(steps/min): Median cadence (steps per minute) in the bout.
- Cadence75th(steps/min): 75th percentile cadence (steps per minute) in the bout.
- ENMO(mg): Bout mean ENMO (milli-g).
- ENMOMed(mg): Bout median ENMO (milli-g).

Output file: \<input-file\>-Bouts.csv.gz