### PR TITLE
Ignore incomplete minute at the start of a recording

### DIFF
--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -102,6 +102,17 @@ def main():
         resample_hz=30 if args.model_type == 'ssl' else None,
         verbose=verbose
     )
+    # Trim data to start of first complete minute to ensure that detection window is 
+    # always alligned with the start of a minute and not with the start of the recording.
+    TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+    cnt = 0
+    while cnt < 10000:
+        start_time = data.index[cnt].strftime(TIME_FORMAT)
+        if start_time.endswith(":00"):
+            data = data.loc[start_time:]
+            break
+        cnt += 1
+    
     info.update(info_read)
 
     # Exclusion: first/last days


### PR DESCRIPTION
This ensures that the first incomplete minute in the data is always ignored, which has the following advantages:
- No ambiguity about the date, hour, or minute a 10 second epoch belongs to.
- Standardised comparison with other software where epochs are aligned to the start of a minute such as GGIR.
- Improved alignment of epoch level time series when working with multiple accelerometers in parallel.

I am helping a group to compare the Verisense step detection algorithm with your classifier and implemented this minor change in a fork to facilitate their comparison. However, maybe you also want it to be part of the actual code base.
