### PR TITLE
Add `--start-first-complete-minute` CLI option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=False,
     install_requires=[
-        "actipy>=3.7.0",
+        "actipy>=3.8.0",
         "numpy==1.24.*",
         "scipy==1.10.*",
         "pandas==2.0.*",

--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -77,6 +77,8 @@ def main():
                         type=str, default=None)
     parser.add_argument("--calibration-stdtol-min", help="Minimum standard deviation tolerance for detection of stationary periods for calibration.",
                         type=float, default=None)
+    parser.add_argument("--start-first-complete-minute", action='store_true',
+                        help="Start data from the first complete minute (uses 1 second tolerance)")
     parser.add_argument('--quiet', '-q', action='store_true', help='Suppress output')
     args = parser.parse_args()
 
@@ -96,13 +98,14 @@ def main():
 
     # Load file
     data, info_read = utils.read(
-        args.filepath, 
-        usecols=args.txyz, 
+        args.filepath,
+        usecols=args.txyz,
         start_time=args.start,
         end_time=args.end,
         calibration_stdtol_min=args.calibration_stdtol_min,
-        sample_rate=args.sample_rate, 
+        sample_rate=args.sample_rate,
         resample_hz=30 if args.model_type == 'ssl' else None,
+        start_first_complete_minute=args.start_first_complete_minute,
         verbose=verbose
     )
     info.update(info_read)

--- a/src/stepcount/utils.py
+++ b/src/stepcount/utils.py
@@ -17,18 +17,21 @@ def read(
     calibration_stdtol_min: float = None,
     sample_rate: float = None,
     resample_hz: str = 'uniform',
+    start_first_complete_minute: bool = False,
     verbose: bool = True
 ):
     """
     Read and preprocess activity data from a file.
 
-    This function reads activity data from various file formats, processes it using the `actipy` library, 
+    This function reads activity data from various file formats, processes it using the `actipy` library,
     and returns the processed data along with metadata information.
 
     Parameters:
     - filepath (str): The path to the file containing activity data.
-    - usecols (str, optional): A comma-separated string of column names to use when reading CSV files. 
+    - usecols (str, optional): A comma-separated string of column names to use when reading CSV files.
       Default is 'time,x,y,z'.
+    - start_first_complete_minute (bool, optional): Whether to start data from the first complete minute.
+      Uses 1 second tolerance. Default is False.
     - calibration_stdtol_min (float, optional): The minimum standard deviation tolerance for detecting stationary periods for calibration. If None,
       no minimum is applied. Default is None.
     - resample_hz (str, optional): The resampling frequency for the data. If 'uniform', it will use `sample_rate`
@@ -89,6 +92,7 @@ def read(
             calibrate_gravity_kwargs={'stdtol_min': calibration_stdtol_min},
             detect_nonwear=True,
             resample_hz=resample_hz,
+            start_first_complete_minute=start_first_complete_minute,
             verbose=verbose,
         )
 
@@ -108,6 +112,7 @@ def read(
             calibrate_gravity_kwargs={'stdtol_min': calibration_stdtol_min},
             detect_nonwear=True,
             resample_hz=resample_hz,
+            start_first_complete_minute=start_first_complete_minute,
             verbose=verbose,
         )
 


### PR DESCRIPTION
Added command-line option to start data from the first complete minute with 1 second tolerance. This aligns with actipy's functionality and provides users with more control over data alignment.

- Added CLI argument --start-first-complete-minute to stepcount.py
- Added parameter to utils.read() function
- Passed parameter through to actipy.process() and actipy.read_device()
- Updated actipy version requirement to 3.8.0 for compatibility

Closes https://github.com/OxWearables/stepcount/pull/160