### PR TITLE
Add offline model support: --ssl-repo-path and --download-models

### DIFF
--- a/src/stepcount/models.py
+++ b/src/stepcount/models.py
@@ -374,12 +374,14 @@ class WalkDetectorSSL:
         batch_size=100,
         weights_path='state_dict.pt',
         repo_tag='v1.0.0',
+        ssl_repo_path=None,
         hmm_params=None,
         verbose=False,
     ):
         self.device = device
         self.weights_path = weights_path
         self.repo_tag = repo_tag
+        self.ssl_repo_path = ssl_repo_path
         self.batch_size = batch_size
         self.state_dict = None
 
@@ -434,7 +436,8 @@ class WalkDetectorSSL:
         walk = c[1]
         class_weights = [(walk * 9.0) / notwalk, 1.0]
 
-        model = sslmodel.get_sslnet(tag=self.repo_tag, pretrained=True)
+        model = sslmodel.get_sslnet(tag=self.repo_tag, pretrained=True,
+                                    repo_path=getattr(self, 'ssl_repo_path', None))
         model.to(self.device)
 
         sslmodel.train(model, train_loader, val_loader, self.device, class_weights, weights_path=self.weights_path)
@@ -482,7 +485,8 @@ class WalkDetectorSSL:
 
     def load_model(self):
 
-        model = sslmodel.get_sslnet(tag=self.repo_tag, pretrained=False)
+        model = sslmodel.get_sslnet(tag=self.repo_tag, pretrained=False,
+                                    repo_path=getattr(self, 'ssl_repo_path', None))
         model.load_state_dict(self.state_dict)
         model.to(self.device)
 

--- a/src/stepcount/sslmodel.py
+++ b/src/stepcount/sslmodel.py
@@ -216,6 +216,8 @@ def get_sslnet(tag='v1.0.0', pretrained=False, repo_path=None):
     :param bool pretrained: Initialise the model with UKB self-supervised pretrained weights.
     :param repo_path: Path to a local copy of the ssl-wearables repo. When provided, uses this
         directly with source='local', skipping GitHub download and cache lookup.
+        Note: when repo_path is provided, the tag parameter is ignored — the caller
+        is responsible for ensuring the local repo matches the expected version.
     :return: pytorch SSL model
     :rtype: nn.Module
     """

--- a/src/stepcount/sslmodel.py
+++ b/src/stepcount/sslmodel.py
@@ -208,15 +208,23 @@ class EarlyStopping:
         self.val_loss_min = val_loss
 
 
-def get_sslnet(tag='v1.0.0', pretrained=False):
+def get_sslnet(tag='v1.0.0', pretrained=False, repo_path=None):
     """
     Load and return the Self Supervised Learning (SSL) model from pytorch hub.
 
     :param str tag: Tag on the ssl-wearables repo to check out
     :param bool pretrained: Initialise the model with UKB self-supervised pretrained weights.
+    :param repo_path: Path to a local copy of the ssl-wearables repo. When provided, uses this
+        directly with source='local', skipping GitHub download and cache lookup.
     :return: pytorch SSL model
     :rtype: nn.Module
     """
+
+    if repo_path is not None:
+        sslnet: nn.Module = torch.hub.load(str(repo_path), 'harnet10', trust_repo=True,
+                                           source='local', class_num=2, pretrained=pretrained,
+                                           verbose=verbose)
+        return sslnet
 
     repo_name = 'ssl-wearables'
     repo = f'OxWearables/{repo_name}:{tag}'

--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -31,7 +31,7 @@ def main():
         description="A tool to estimate step counts from accelerometer data",
         add_help=True
     )
-    parser.add_argument("filepath", help="Enter file to be processed")
+    parser.add_argument("filepath", nargs='?', default=None, help="Enter file to be processed")
     parser.add_argument("--outdir", "-o", help="Enter folder location to save output files", default="outputs/")
     parser.add_argument("--model-path", "-m", help="Enter custom model file to use", default=None)
     parser.add_argument("--force-download", action="store_true", help="Force download of model file")
@@ -93,8 +93,17 @@ def main():
     parser.add_argument("--csv-txyz-idxs",
                         help="Column indices for time,x,y,z (0-indexed, e.g., '0,1,2,3'). Overrides --csv-txyz.",
                         type=str, default=None)
+    parser.add_argument("--download-models", action="store_true",
+                        help="Download all model files and exit. No input file needed.")
     parser.add_argument('--quiet', '-q', action='store_true', help='Suppress output')
     args = parser.parse_args()
+
+    if args.download_models:
+        download_models(force_download=args.force_download, ssl_repo_path=args.ssl_repo_path)
+        return
+
+    if args.filepath is None:
+        parser.error("filepath is required (unless using --download-models)")
 
     before = time.time()
 
@@ -461,6 +470,47 @@ def main():
 
     after = time.time()
     print(f"Done! ({round(after - before,2)}s)")
+
+
+def download_models(force_download=False, ssl_repo_path=None):
+    """Download all model files for offline use."""
+
+    for model_type in ('ssl', 'rf'):
+        pth = pathlib.Path(__file__).parent / f"{__model_version__[model_type]}.joblib.lzma"
+        if force_download or not pth.exists():
+            url = f"https://wearables-files.ndph.ox.ac.uk/files/models/stepcount/{__model_version__[model_type]}.joblib.lzma"
+            print(f"Downloading {url}...")
+            tmp_pth = pth.with_suffix('.tmp')
+            try:
+                with urllib.request.urlopen(url, timeout=60) as f_src, open(tmp_pth, "wb") as f_dst:
+                    shutil.copyfileobj(f_src, f_dst)
+                if utils.md5(tmp_pth) != __model_md5__[model_type]:
+                    raise ValueError(
+                        f"MD5 mismatch for {model_type} model. Download may be corrupted."
+                    )
+                os.replace(tmp_pth, pth)
+            except Exception:
+                if tmp_pth.exists():
+                    tmp_pth.unlink()
+                raise
+            print(f"Saved to {pth}")
+        else:
+            print(f"Already exists: {pth}")
+
+    # Cache ssl-wearables repo
+    if ssl_repo_path is None:
+        from stepcount import sslmodel
+        print("Caching ssl-wearables repo...")
+        sslmodel.get_sslnet(tag='v1.0.0', pretrained=False)
+        print("Done caching ssl-wearables repo.")
+    else:
+        if not pathlib.Path(ssl_repo_path).is_dir():
+            raise FileNotFoundError(
+                f"--ssl-repo-path does not exist or is not a directory: {ssl_repo_path}"
+            )
+        print(f"Using local ssl-wearables repo: {ssl_repo_path}")
+
+    print("All models downloaded.")
 
 
 def load_model(

--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -40,6 +40,9 @@ def main():
                         choices=['ssl', 'rf'], default='ssl')
     parser.add_argument("--pytorch-device", "-d", help="Pytorch device to use, e.g.: 'cpu' or 'cuda:0' (for SSL only)",
                         type=str, default='cpu')
+    parser.add_argument("--ssl-repo-path",
+                        help="Path to a local copy of the ssl-wearables repo for offline use (SSL only)",
+                        type=str, default=None)
     parser.add_argument("--sample-rate", "-r", help="Sample rate for measurement, otherwise inferred.",
                         type=int, default=None)
     parser.add_argument("--csv-txyz",
@@ -167,6 +170,8 @@ def main():
     model.wd.verbose = verbose
 
     model.wd.device = args.pytorch_device
+    if args.ssl_repo_path is not None:
+        model.wd.ssl_repo_path = args.ssl_repo_path
 
     Y, W, T_steps = model.predict_from_frame(data)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -483,6 +483,22 @@ class TestWalkDetectorSSLBasic:
         assert detector.device == 'cpu'
         assert detector.batch_size == 100
 
+    def test_walk_detector_ssl_init_with_repo_path(self):
+        """Test WalkDetectorSSL stores ssl_repo_path."""
+        detector = models.WalkDetectorSSL(
+            device='cpu',
+            ssl_repo_path='/my/local/ssl-wearables',
+            verbose=False
+        )
+
+        assert detector.ssl_repo_path == '/my/local/ssl-wearables'
+
+    def test_walk_detector_ssl_init_default_repo_path(self):
+        """Test WalkDetectorSSL defaults ssl_repo_path to None."""
+        detector = models.WalkDetectorSSL(device='cpu', verbose=False)
+
+        assert detector.ssl_repo_path is None
+
     @pytest.mark.skip(reason="SSL model requires valid state_dict to be loaded before predict (needs model weights)")
     def test_walk_detector_ssl_predict_empty(self):
         """Test WalkDetectorSSL handles empty input.

--- a/tests/test_sslmodel.py
+++ b/tests/test_sslmodel.py
@@ -243,6 +243,34 @@ class TestGetSSLNet:
         call_kwargs = mock_hub_load.call_args[1]
         assert call_kwargs['pretrained'] is True
 
+    @patch('stepcount.sslmodel.torch.hub.load')
+    def test_repo_path_uses_local_source(self, mock_hub_load):
+        """When repo_path is provided, should use source='local' and skip cache lookup."""
+        mock_model = Mock(spec=nn.Module)
+        mock_hub_load.return_value = mock_model
+
+        result = sslmodel.get_sslnet(repo_path='/my/local/ssl-wearables')
+
+        assert result == mock_model
+        mock_hub_load.assert_called_once()
+        call_args = mock_hub_load.call_args
+        assert call_args[0][0] == '/my/local/ssl-wearables'
+        assert call_args[1]['source'] == 'local'
+
+    @patch('stepcount.sslmodel.torch.hub.load')
+    @patch('stepcount.sslmodel.torch_cache_path')
+    def test_no_repo_path_uses_cache_logic(self, mock_cache_path, mock_hub_load):
+        """When repo_path is None, should use the existing GitHub/cache logic."""
+        mock_cache_path.exists.return_value = True
+        mock_cache_path.iterdir.return_value = []
+        mock_hub_load.return_value = Mock(spec=nn.Module)
+
+        sslmodel.get_sslnet(repo_path=None)
+
+        call_args = mock_hub_load.call_args
+        # Should use github source when no local cache exists
+        assert call_args[1]['source'] == 'github'
+
 
 class TestPredict:
     """Tests for predict function."""

--- a/tests/test_stepcount.py
+++ b/tests/test_stepcount.py
@@ -559,6 +559,17 @@ class TestCLIEndToEnd:
         )
         assert result.returncode == 0
 
+    def test_cli_ssl_repo_path_option(self):
+        """Test that --ssl-repo-path option is recognized."""
+        result = subprocess.run(
+            [sys.executable, '-m', 'stepcount.stepcount', '--help'],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        assert result.returncode == 0
+        assert '--ssl-repo-path' in result.stdout
+
     @pytest.fixture
     def small_csv_file(self, tmp_path):
         """Create a small CSV file for quick E2E testing."""

--- a/tests/test_stepcount.py
+++ b/tests/test_stepcount.py
@@ -570,6 +570,37 @@ class TestCLIEndToEnd:
         assert result.returncode == 0
         assert '--ssl-repo-path' in result.stdout
 
+    def test_cli_download_models_in_help(self):
+        """Test that --download-models appears in --help output."""
+        result = subprocess.run(
+            [sys.executable, '-m', 'stepcount.stepcount', '--help'],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        assert result.returncode == 0
+        assert '--download-models' in result.stdout
+
+    def test_cli_download_models_no_filepath(self):
+        """Test that --download-models works without a filepath argument."""
+        from unittest.mock import patch
+        with patch('stepcount.stepcount.download_models') as mock_dl:
+            # Simulate calling main() with --download-models
+            with patch('sys.argv', ['stepcount', '--download-models']):
+                stepcount.main()
+            mock_dl.assert_called_once_with(force_download=False, ssl_repo_path=None)
+
+    def test_cli_no_filepath_no_download_models(self):
+        """Test that omitting filepath without --download-models gives an error."""
+        result = subprocess.run(
+            [sys.executable, '-m', 'stepcount.stepcount'],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        assert result.returncode != 0
+        assert 'filepath' in result.stderr.lower() or 'required' in result.stderr.lower()
+
     @pytest.fixture
     def small_csv_file(self, tmp_path):
         """Create a small CSV file for quick E2E testing."""


### PR DESCRIPTION

Users in offline or restricted environments have no way to pre-download all model artifacts. The `.joblib.lzma` files are fetched lazily on first run, and the `ssl-wearables` torch hub repo is cloned when the SSL model loads. This PR adds `--ssl-repo-path` to use a local repo copy and `--download-models` to pre-cache everything ahead of time.

## Files Changed
**`src/stepcount/sslmodel.py`**
- Add `repo_path` parameter to `get_sslnet()`. When provided, loads via `torch.hub.load()` with `source='local'`, skipping GitHub download and cache lookup
- Document that `tag` is ignored when `repo_path` is provided

**`src/stepcount/models.py`**
- Add `ssl_repo_path` parameter to `WalkDetectorSSL.__init__()`
- Pass it through to `get_sslnet()` in `fit()` and `load_model()`
- Use `getattr` for backward compat with models serialized before this change

**`src/stepcount/stepcount.py`**
- Add `--ssl-repo-path` CLI argument for specifying a local ssl-wearables repo (SSL only)
- Wire it to `model.wd.ssl_repo_path` after model loading
- Make `filepath` positional arg optional (`nargs='?'`) so `--download-models` works without an input file
- Add `--download-models` CLI flag and early-exit logic in `main()`
- Add `download_models()` function: downloads both ssl and rf `.joblib.lzma` files with atomic temp-file writes, MD5 verification, 60s timeout; caches ssl-wearables repo; validates `--ssl-repo-path` if provided

**`tests/test_sslmodel.py`**
- Test `repo_path` uses `source='local'` and skips cache logic
- Test `repo_path=None` falls back to existing GitHub/cache logic

**`tests/test_models.py`**
- Test `WalkDetectorSSL` stores and defaults `ssl_repo_path`

**`tests/test_stepcount.py`**
- Test `--ssl-repo-path` appears in CLI help output
- Test `--download-models` appears in CLI help output
- Test `--download-models` works without a filepath arg (mocked)
- Test omitting filepath without `--download-models` gives an error