### PR TITLE
Auto-detect MPS device for SSL model on Apple Silicon

### DIFF
--- a/src/stepcount/models.py
+++ b/src/stepcount/models.py
@@ -47,7 +47,7 @@ class StepCounter:
 
         if wd_type == 'ssl':
             wd_defaults = {
-                'device': 'cpu',
+                'device': 'mps' if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available() else 'cpu',
                 'batch_size': 100,
                 'verbose': verbose
             }
@@ -489,6 +489,9 @@ class WalkDetectorSSL:
                                     repo_path=getattr(self, 'ssl_repo_path', None))
         model.load_state_dict(self.state_dict)
         model.to(self.device)
+
+        if self.verbose:
+            print(f"Using pytorch device: {self.device}")
 
         return model
 

--- a/src/stepcount/stepcount.py
+++ b/src/stepcount/stepcount.py
@@ -38,8 +38,9 @@ def main():
     parser.add_argument('--model-type', '-t',
                         help='Enter model type to run (Self-Supervised Learning model or Random Forest)',
                         choices=['ssl', 'rf'], default='ssl')
-    parser.add_argument("--pytorch-device", "-d", help="Pytorch device to use, e.g.: 'cpu' or 'cuda:0' (for SSL only)",
-                        type=str, default='cpu')
+    parser.add_argument("--pytorch-device", "-d", help="Pytorch device to use, e.g.: 'cpu' or 'cuda:0' (for SSL only). "
+                        "Default: 'mps' if available, otherwise 'cpu'",
+                        type=str, default=None)
     parser.add_argument("--ssl-repo-path",
                         help="Path to a local copy of the ssl-wearables repo for offline use (SSL only)",
                         type=str, default=None)
@@ -178,7 +179,11 @@ def main():
     model.verbose = verbose
     model.wd.verbose = verbose
 
-    model.wd.device = args.pytorch_device
+    if args.pytorch_device is not None:
+        model.wd.device = args.pytorch_device
+    elif args.model_type == 'ssl':
+        import torch
+        model.wd.device = 'mps' if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available() else 'cpu'
     if args.ssl_repo_path is not None:
         model.wd.ssl_repo_path = args.ssl_repo_path
 


### PR DESCRIPTION
# Auto-detect MPS device for SSL model on Apple Silicon

The SSL torch model runs significantly slower on Apple Silicon macOS when using CPU compared to Intel, because PyTorch's ARM64 CPU backend has less optimized Conv1d kernels. This change auto-detects and uses the MPS (Metal Performance Shaders) backend when available, which provides meaningful speedup for CNN inference on Apple Silicon.

Users can still override with `--pytorch-device cpu` if needed.

## Files Changed
**`src/stepcount/models.py`**
- `StepCounter.__init__`: default device changed from `'cpu'` to auto-detect MPS via `torch.backends.mps.is_available()`, with `hasattr` guard for pre-1.12 PyTorch
- `WalkDetectorSSL.load_model`: log device in verbose mode

**`src/stepcount/stepcount.py`**
- `--pytorch-device` CLI default changed from `'cpu'` to `None` (auto-detect), help text updated
- Deserialized joblib models now get their device overridden to MPS when available (previously the baked-in `'cpu'` from training time was always used)

Closes https://github.com/OxWearables/stepcount/issues/102
